### PR TITLE
Added a setting to excluse certain forums from Telegram

### DIFF
--- a/adm/style/acp_telegramnotifications_settings.html
+++ b/adm/style/acp_telegramnotifications_settings.html
@@ -79,6 +79,13 @@
 							  <!-- IF not LASSIK_TELEGRAM_INCLUDE_TEXT --> checked="checked" <!-- ENDIF --> value="0"> {L_NO}</label>
 			</dd>
 		</dl>
+	        <dl>
+                        <dt><label for="lassik_telegram_chat_forums">
+                                        {L_ACP_TELEGRAM_CHAT_FORUMS}{L_COLON}</label></dt>
+                        <dd><input type="text" name="lassik_telegram_chat_forums"
+                                           value="{LASSIK_TELEGRAM_CHAT_FORUMS}" size="50"></dd>
+                </dl>
+
 	</fieldset>
 	<fieldset class="submit-buttons">
 		<legend>Submit</legend>

--- a/controller/acp_controller.php
+++ b/controller/acp_controller.php
@@ -29,6 +29,7 @@ class acp_controller
 	private $string_vars = array(
 		'lassik_telegram_bot_auth_token',
 		'lassik_telegram_chat_id',
+		'lassik_telegram_chat_forums',
 	);
 
 	private $bool_vars = array(

--- a/core/functions.php
+++ b/core/functions.php
@@ -213,9 +213,18 @@ class functions
 				$this->get_bool_config_var('lassik_telegram_include_text'));
 	}
 
-	public function notify_about_post($url, $username, $mode, $title, $extra)
+	private function is_forum_excluded($forum_id)
 	{
-		if (!$this->should_notify_about_post_mode($mode))
+		$forums_excluded = preg_split("/[\s,]+/", $this->config['lassik_telegram_chat_forums']);
+
+		return in_array($forum_id, $forums_excluded);
+	}
+
+	public function notify_about_post($url, $username, $mode, $title, $extra, $forum_id)
+	{
+
+
+		if (!$this->should_notify_about_post_mode($mode) || $this->is_forum_excluded($forumid))
 		{
 			return;
 		}

--- a/core/functions.php
+++ b/core/functions.php
@@ -216,18 +216,16 @@ class functions
 	private function is_forum_excluded($forum_id)
 	{
 		$forums_excluded = preg_split("/[\s,]+/", $this->config['lassik_telegram_chat_forums']);
-
 		return in_array($forum_id, $forums_excluded);
 	}
 
 	public function notify_about_post($url, $username, $mode, $title, $extra, $forum_id)
 	{
-
-
-		if (!$this->should_notify_about_post_mode($mode) || $this->is_forum_excluded($forumid))
+		if (!$this->should_notify_about_post_mode($mode) || $this->is_forum_excluded($forum_id))
 		{
 			return;
 		}
+
 		$html = htmlspecialchars($this->prefix_for_post_mode($mode, $username)).
 			  '<a href="'.htmlspecialchars($url).'">'.
 			  htmlspecialchars($title).

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -91,7 +91,11 @@ class main_listener implements EventSubscriberInterface
 			$extra = html_entity_decode($extra);
 			$extra = strip_tags($extra);
 		}
+
+		$forum_id = $event['data']['forum_id'];
+
 		$this->functions->notify_about_post(
-			$url, $username, $mode, $title, $extra);
+			$url, $username, $mode, $title, $extra, $forum_id);
+
 	}
 }

--- a/language/en/info_acp_namespace.php
+++ b/language/en/info_acp_namespace.php
@@ -20,6 +20,7 @@ if (empty($lang) || !is_array($lang))
 $lang = array_merge($lang, array(
 	'ACP_TELEGRAM_BOT_AUTH_TOKEN'	=> 'Telegram bot auth token',
 	'ACP_TELEGRAM_CHAT_ID'			=> 'Telegram chat ID',
+        'ACP_TELEGRAM_CHAT_FORUMS'              => 'Forums to exclude, sepparated by comma',
 	'ACP_TELEGRAM_CONNECTION'		=> 'Telegram connection',
 	'ACP_TELEGRAM_ERROR'			=> 'Error message',
 	'ACP_TELEGRAM_FIND_CHAT_ID'		=> 'Find chat ID',


### PR DESCRIPTION
Hello,

I have not enough time to test this, but I had an idea. Could it possible to exclude certain forums from the notifications? We are announcing some posts that are in an adminsitrative forum and we would like to exclude it from Telegram.

Best regards.